### PR TITLE
Write files with umask 0002 in Docker container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Next version
+
+* [#24](https://github.com/sdss/lvmguider/pull/24) Ensure group write permissions for new files in Docker container.
+
+
 ## 0.5.3 - June 1, 2024
 
 ### 🔧 Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next version
 
+### ✨ Improved
+
 * [#24](https://github.com/sdss/lvmguider/pull/24) Ensure group write permissions for new files in Docker container.
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,11 @@ RUN cd lvmguider && pip3 install .
 RUN rm -Rf lvmguider
 
 # Set umask so that new files inherit the parent folder permissions.
+# Not sure this works so we are also setting the permissions in the entrypoint.
 RUN echo "umask 0002" >> /etc/bash.bashrc
 
-ENTRYPOINT pip3 install -U astropy-iers-data; lvmguider actor start --debug
+COPY ./docker/docker-entrypoint.sh /
+RUN ["chmod", "+x", "/docker-entrypoint.sh"]
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["sh", "-c", "lvmguider actor start --debug"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+umask 0002
+
+pip3 install -U astropy-iers-data
+exec "$@"


### PR DESCRIPTION
Enforce setting the `umask` to 0002 so that files written by the actor in a container have write permissions for group.